### PR TITLE
Improve OpenAI client handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@
 
 
 ## 使い方
-.envに以下設定
+1. `.env.example` を `.env` にコピーし、OpenAI API キーを設定します。
 ```
-OPENAI_API_KEY=xxxxxxxxx(openAiのapiキーを取得して設定してください(課金しないと使えません))
+cp .env.example .env
+# .env を開いて OPENAI_API_KEY に自身のキーを設定
 ```
 
 ```
 streamlit run app.py
+```
+
+CLI での利用例:
+```
+python main.py --query "ログインフォームの異常系テスト"
 ```
 
 ## 出力例

--- a/app.py
+++ b/app.py
@@ -1,8 +1,7 @@
 import os
 import json
 import streamlit as st
-from dotenv import load_dotenv
-from openai import OpenAI
+from rag_utils.openai_client import get_openai_client
 from langchain_community.vectorstores import Chroma
 from langchain_openai import OpenAIEmbeddings
 from langchain_core.documents import Document
@@ -12,8 +11,7 @@ import markdown
 from collections import defaultdict
 
 # 初期化
-load_dotenv()
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = get_openai_client()
 embedding = OpenAIEmbeddings(model="text-embedding-3-small", dimensions=1536)
 
 PERSIST_DIR = "chroma_db"

--- a/main.py
+++ b/main.py
@@ -1,19 +1,15 @@
 import os
 import json
 import argparse
-from dotenv import load_dotenv
-from openai import OpenAI
+from rag_utils.openai_client import get_openai_client
 from langchain_community.vectorstores import Chroma
 from langchain_openai import OpenAIEmbeddings
 from langchain_core.documents import Document
 from pathlib import Path
 import markdown
 
-# 環境変数読み込み
-load_dotenv()
-
 # OpenAIクライアント初期化
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = get_openai_client()
 
 # Embeddingモデル初期化（節約版）
 embedding = OpenAIEmbeddings(


### PR DESCRIPTION
## Summary
- use shared `get_openai_client` helper in `app.py` and `main.py`
- document CLI usage and `.env` setup
- add `.env.example` template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a0742308832db0e4956697d8e1c9